### PR TITLE
Implemented reusable grid table. 

### DIFF
--- a/frontend/src/__tests__/grid_table_test.jsx
+++ b/frontend/src/__tests__/grid_table_test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/';
+import GridTable from '../components/shared/grid_table';
+
+const rowData = [
+    { test_id: '1', test_name: 'Chungus McTesterdon', test_sandwich: 'BLT', dev_dreams: 'job' },
+    { test_id: '2', test_name: 'Real TestName', test_sandwich: 'Club', dev_dreams: 'thesis' },
+  ];
+  
+const columnDefs = [
+    { field: 'test_id', headerName: 'TEST ID' },
+    { field: 'test_name', headerName: 'TEST NAME' },
+    { field: 'test_sandwich', headerName: 'EAT ME' },
+    { field: 'dev_dreams', headerName: 'CRUSHED' },
+];
+
+describe('GridTable Component', () => {
+
+    test('renders the correct column headers', () => {
+        const { getByText } = render(<GridTable rowData={rowData} columnDefs={columnDefs} />);
+        expect(getByText('TEST ID')).toBeInTheDocument();
+        expect(getByText('TEST NAME')).toBeInTheDocument();
+        expect(getByText('EAT ME')).toBeInTheDocument();
+        expect(getByText('CRUSHED')).toBeInTheDocument();
+    });
+
+    test('renders the correct number of rows', () => {
+        const { getAllByRole } = render(<GridTable rowData={rowData} columnDefs={columnDefs} />);
+        const rows = getAllByRole('row');
+        expect(rows.length).toBe(4); // Take in account header and floating filter rows.
+    });
+
+    test('renders the correct data cells', () => {
+        const { getByText } = render(<GridTable rowData={rowData} columnDefs={columnDefs} />);
+        expect(getByText('Chungus McTesterdon')).toBeInTheDocument();
+        expect(getByText('BLT')).toBeInTheDocument();
+        expect(getByText('job')).toBeInTheDocument();
+
+        expect(getByText('Real TestName')).toBeInTheDocument();
+        expect(getByText('Club')).toBeInTheDocument();
+        expect(getByText('thesis')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/shared/grid_table.jsx
+++ b/frontend/src/components/shared/grid_table.jsx
@@ -1,14 +1,40 @@
-import { AgGridReact } from 'ag-grid-react'; // React Data Grid Component
-import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the Data Grid
-import "ag-grid-community/styles/ag-theme-quartz.css"; // Optional, might change when testing different styles
+import React from 'react';
+import Box from '@mui/material/Box';
+import { AgGridReact } from 'ag-grid-react';
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-quartz.css";
 
-const Grid_table = ({}) => {
+const Grid_table = ({rowData, columnDefs}) => {
+  return (
+    <Box
+      sx={{
+        flexDirection: 'column',
+        alignItems: 'center',
+        mt: 1,
+        mb: 4,
+        maxWidth: 1000,
+      }}
+      className="ag-theme-quartz"
+      style={{ width: '95vw', height: '80vh' }}
+    >
+      <AgGridReact
+        rowData={rowData} 
+        columnDefs={columnDefs} 
+        defaultColDef={{ 
+          resizable: false, 
+          sortable: true, 
+          filter: true,
+          floatingFilter: true, 
+          minWidth: 100 
+        }} 
+        animateRows={true}
+        pagination={true} 
+        paginationAutoPageSize = {true}
+        paginationPageSizeSelector={false}
+        style={{ flexGrow: 1 }}
+      />
+    </Box>
+  );
+};
 
-    return (
-      <div>
-        
-      </div>
-    );
-  };
-  
-  export default Grid_table;
+export default Grid_table;


### PR DESCRIPTION
### Implemented reusable grid table and unit tests for it.

Takes rowData and columnDefs as parameters.
columnDef is an array that contains all columns and their formatting. 
Example column definition: { field: "dev_id", filter: "agNumberColumnFilter", headerName: "ID", flex: 1 },
rowData is data imported from the API for the wanted columns.

Currently cells can't be changed after rendering, but this can be achieved with AgGrid once we have the API running.

Rendering the grid on a phone-sized screen with a _mock_ API and a **WIP** Device view looks like the following:
<img width="250" alt="grid table" src="https://github.com/user-attachments/assets/fd34bd4d-3935-4d82-91a0-4e731cf43b1e">


Closes #39 