### PR TITLE
Implemented device_register_grid and added unit tests for it.

### DIFF
--- a/frontend/src/__tests__/device_register_grid_test.jsx
+++ b/frontend/src/__tests__/device_register_grid_test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DeviceGrid from '../components/device_register/device_register_grid';
+import useFetchData from '../components/shared/fetch_data';
+import '@testing-library/jest-dom';
+
+jest.mock('../components/shared/fetch_data');
+
+describe('DeviceRegisterGrid Component', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('displays loading message when fetching data', () => {
+        useFetchData.mockReturnValue({ data: [], loading: true, error: null });
+
+        render(<DeviceGrid />);
+
+        expect(screen.getByText('Loading devices...')).toBeInTheDocument();
+    });
+
+    test('displays error message on error', () => {
+        useFetchData.mockReturnValue({
+             data: [], loading: false, error: new Error('Failed to fetch') });
+        
+        render(<DeviceGrid />);
+
+        // Assert that the error message is displayed correctly.
+        expect(screen.getByText(/Failed to load devices\.\s*Please try again later\./)).toBeInTheDocument();
+    });
+
+    test('renders the data grid with the fetched data', async () => {
+        useFetchData.mockReturnValue({
+            data: [
+                { 
+                    dev_id: 1, 
+                    dev_class: 'Sensor', 
+                    dev_name: 'Temperature Sensor', 
+                    dev_manufacturer: 'Acme Corp' 
+                },
+            ],
+            loading: false,
+            error: null,
+        });
+
+        render(<DeviceGrid />);
+
+        // Cells
+        expect(screen.getByText('Temperature Sensor')).toBeInTheDocument();
+        expect(screen.getByText('Sensor')).toBeInTheDocument();
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+        // Headers
+        expect(screen.getByText('ID')).toBeInTheDocument();
+        expect(screen.getByText('Type')).toBeInTheDocument();
+        expect(screen.getByText('Device')).toBeInTheDocument();
+        expect(screen.getByText('Location')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/device_register/device_register_grid.jsx
+++ b/frontend/src/components/device_register/device_register_grid.jsx
@@ -1,44 +1,41 @@
 import React from 'react';
-import { useEffect, useState } from 'react';
+import GridTable from '../shared/grid_table.jsx';
+import Typography from '@mui/material/Typography';
+import useFetchData from '../shared/fetch_data';
 
 const Device_register_grid = () => {
+    const { data: devices, loading, error } = useFetchData('devices');
 
-  const [devices, setDevices] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+    const columnDefs = [
+        { field: "dev_id", filter: "agTextColumnFilter", headerName: "ID", flex: 2 },
+        { field: "dev_class", filter: "agTextColumnFilter", headerName: "Type", flex: 2 },
+        { field: "dev_name", filter: "agTextColumnFilter", headerName: "Device", flex: 2.5 },
+        { field: "dev_manufacturer", filter: "agTextColumnFilter", headerName: "Location", flex: 2.5 },
+    ];
 
-  //Fetch devices from the api
-  useEffect(() => {
-    const fetchDevices = async () => {
-      try {
-        const response = await fetch('http://localhost:5000/api/devices');
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        const data = await response.json();
-        setDevices(data);
-      } catch (error) {
-        setError(error.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-    
-    fetchDevices();
-    
-  }, []);
-
-  useEffect(() => {
-    if (devices.length > 0) {
-      console.log('devices:', devices[0]);
+    if (loading) {
+        return (
+            <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 10vw, 2.4rem)' }}>
+                Loading devices...
+            </Typography>
+        );
     }
-  }, [devices]);
 
-  return (
-    <div>
+    if (error) {
+        return (
+            <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 9vw, 2.4rem)', color: 'red' }}>
+                Failed to load devices.<br />
+                Please try again later.<br />
+            </Typography>
+        );
+    }
 
-    </div>
-  );
+    return (
+        <GridTable 
+            rowData={devices.length > 0 ? devices : []} 
+            columnDefs={columnDefs}
+        />
+    );
 };
 
 export default Device_register_grid;


### PR DESCRIPTION
### Implemented device_register_grid 

Device grid that uses the updated grid_table. Currently uses the endpoint /devices, which doesn't contain
Location, so it is spoofed with dev_manufacturer for now. This will be updated when API has the right table.

closes #46 
