### PR TITLE
Implemented Device Register View.

### DIFF
--- a/frontend/src/__tests__/device_register_view_test.jsx
+++ b/frontend/src/__tests__/device_register_view_test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DeviceRegisterView from '../views/device_register_view';
+import '@testing-library/jest-dom';
+
+jest.mock('../components/shared/navigation_bar', () => {
+    const MockedNavigationBar = () => <div>Mocked NavigationBar</div>;
+    MockedNavigationBar.displayName = 'MockedNavigationBar'; // eslint wants this.
+    return MockedNavigationBar;
+});
+
+jest.mock('../components/device_register/device_register_grid', () => {
+    const MockedDeviceGrid = () => <div>Mocked DeviceGrid</div>;
+    MockedDeviceGrid.displayName = 'MockedDeviceGrid'; // eslint wants this.
+    return MockedDeviceGrid;
+});
+
+describe('DeviceRegisterView Component', () => {
+    test('render Navbar, header, and DeviceGrid correctly', () => {
+
+        render(<DeviceRegisterView />);
+
+        expect(screen.getByText('Mocked NavigationBar')).toBeInTheDocument();
+        expect(screen.getByText('Device Register')).toBeInTheDocument();
+        expect(screen.getByText('Mocked DeviceGrid')).toBeInTheDocument();
+    });
+
+    test('renders the header text with correct styles', () => {
+
+        render(<DeviceRegisterView />);
+
+        const ViewTitle = screen.getByText('Device Register');
+        expect(ViewTitle).toHaveStyle({
+            fontSize: 'clamp(1.5rem, 5vw, 2.4rem)',
+            textAlign: 'center',
+            marginTop: '64px', // 8*8px
+            marginBottom: '24px', // 3*8px
+        });
+    });
+});

--- a/frontend/src/views/device_register_view.jsx
+++ b/frontend/src/views/device_register_view.jsx
@@ -1,13 +1,34 @@
-import DeviceRegisterGrid from '../components/device_register/device_register_grid'
+import React from 'react';
+import Box from '@mui/material/Box';
+import { Typography } from '@mui/material';
+import DeviceGrid from '../components/device_register/device_register_grid';
+import NavigationBar from '../components/shared/navigation_bar';
 
-
-const Device_register_view = () => {
+function Device_register_view() {
 
   return (
-    <div>
-        <DeviceRegisterGrid/>
-    </div>
+    <Box sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%', 
+        height: '100%',
+        overflow: 'hidden',
+        textWrap: 'nowrap'
+    }}>
+        <NavigationBar/>
+        <Typography sx={{
+          fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
+          textAlign: 'center',
+          mt: 8, 
+          mb: 3,
+        }}>
+        Device Register
+        </Typography>
+        <DeviceGrid/>
+    </Box>
   );
-};
+}
 
 export default Device_register_view;


### PR DESCRIPTION
### Implemented Device Register View and unit tests for it.

Device Register view is formed from a Navigation Bar, a title Typography and a Device Grid on top of each other.
This is a P2 ticket, but since it was quick and simple, and combines previous tickets' work, I thought it would be ok.

With mock data, the view looks like this when rendered like on mobile:
<img width="470" alt="Device Register - Final 3 10" src="https://github.com/user-attachments/assets/5b0fc09b-5184-438e-9e93-4b32590119ab">

Closes #49 