### PR TITLE
Implemented Events Grid

### DIFF
--- a/frontend/src/__tests__/event_grid_test.jsx
+++ b/frontend/src/__tests__/event_grid_test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EventGrid from '../components/event_view_components/event_grid';
+import useFetchData from '../components/shared/fetch_data';
+import '@testing-library/jest-dom';
+
+jest.mock('../components/shared/fetch_data');
+
+describe('DeviceRegisterGrid Component', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('displays loading message when fetching data', () => {
+        useFetchData.mockReturnValue({ data: [], loading: true, error: null });
+
+        render(<EventGrid />);
+
+        expect(screen.getByText('Loading devices...')).toBeInTheDocument();
+    });
+
+    test('displays error message on error', () => {
+        useFetchData.mockReturnValue({
+             data: [], loading: false, error: new Error('Failed to fetch') });
+
+        render(<EventGrid />);
+
+        // Assert that the error message is displayed correctly.
+        expect(screen.getByText(/Failed to load devices\.\s*Please try again later\./)).toBeInTheDocument();
+    });
+
+    test('renders the data grid with the fetched data', async () => {
+        useFetchData.mockReturnValue({
+            data: [
+                { 
+                    dev_id: 1, 
+                    user_id: '020202', 
+                    move_time: '2024-10-03T21:12:17.840Z', 
+                    loc_name: 'Test Laboratory' 
+                },
+            ],
+            loading: false,
+            error: null,
+        });
+
+        render(<EventGrid />);
+
+        // Cells
+        expect(screen.getByText('020202')).toBeInTheDocument();
+        expect(screen.getByText('2024-10-03')).toBeInTheDocument();
+        expect(screen.getByText('Test Laboratory')).toBeInTheDocument();
+        // Headers
+        expect(screen.getByText('DEV')).toBeInTheDocument();
+        expect(screen.getByText('USER')).toBeInTheDocument();
+        expect(screen.getByText('Date')).toBeInTheDocument();
+        expect(screen.getByText('Location')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/event_view_components/event_grid.jsx
+++ b/frontend/src/components/event_view_components/event_grid.jsx
@@ -1,11 +1,47 @@
+import React from 'react';
+import GridTable from '../shared/grid_table.jsx';
+import Typography from '@mui/material/Typography';
+import useFetchData from '../shared/fetch_data';
 
 const Event_grid = () => {
+    const { data, loading, error } = useFetchData('events');
 
-  return (
-    <div>
-        
-    </div>
-  );
+    const formattedData = data.map(event => ({
+        ...event,
+        // Format Datetime to just be a Date.
+        move_time: event.move_time.split("T")[0],
+    }));  
+    
+    const columnDefs = [
+        { field: "dev_id", filter: "agTextColumnFilter", headerName: "DEV", flex: 1.5 },
+        { field: "user_id", filter: "agTextColumnFilter", headerName: "USER", flex: 1.5 }, 
+        { field: "move_time", filter: "agDateColumnFilter", headerName: "Date", flex: 2.5, suppressHeaderFilterButton: false, },
+        { field: "loc_name", filter: "agTextColumnFilter", headerName: "Location", flex: 2.0 },
+    ];
+
+    if (loading) {
+        return (
+            <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 10vw, 2.4rem)' }}>
+                Loading devices...
+            </Typography>
+        );
+    }
+
+    if (error) {
+        return (
+            <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 9vw, 2.4rem)', color: 'red' }}>
+                Failed to load devices.<br />
+                Please try again later.<br />
+            </Typography>
+        );
+    }
+
+    return (
+        <GridTable 
+            rowData={formattedData.length > 0 ? formattedData : []} 
+            columnDefs={columnDefs}
+        />
+    );
 };
 
 export default Event_grid;


### PR DESCRIPTION
### Implemented Event Grid. 

Grid currently fetches api/events/, where it gets dev_id, user_id, move_time and loc_name.
This can be updated when we know what is wanted and a new table is in the backend.

The current Event Grid rendered looks like this:
<img width="356" alt="event_grid" src="https://github.com/user-attachments/assets/6f225cda-dda7-44f8-855e-dfce9df310af">
Styling and positioning are identical to Device Grid.

The grid will eventually link to device_info, that functionality will be pushed later.
Closes #47 