### PR TITLE
Updated Device info and Event grids to filter dates properly. 

### DIFF
--- a/frontend/src/__tests__/device_info_grid_test.jsx
+++ b/frontend/src/__tests__/device_info_grid_test.jsx
@@ -47,7 +47,7 @@ describe('Device_info_grid Component', () => {
 
         // Cells
         expect(screen.getByText('toimii')).toBeInTheDocument();
-        expect(screen.getByText('2024-10-08 12:34:56')).toBeInTheDocument();
+        expect(screen.getByText('08/10/2024 12:34:56')).toBeInTheDocument();
         expect(screen.getByText('Labra')).toBeInTheDocument();
         // Headers
         expect(screen.getByText('ID')).toBeInTheDocument();

--- a/frontend/src/components/device_info/device_info_grid.jsx
+++ b/frontend/src/components/device_info/device_info_grid.jsx
@@ -7,17 +7,43 @@ import PropTypes from 'prop-types'
 const Device_info_grid = ({ id }) => {
   const { data: events, loading, error } = useFetchData('devices/' + id + '/events');
 
+  const formattedEvents = events.map(event => ({
+    ...event,
+    // Format move_time to DD/MM/YYYY HH:MM:SS
+    move_time: new Date(event.move_time).toLocaleDateString('en-GB') + ' ' + new Date(event.move_time).toLocaleTimeString('en-GB')
+  }));
+
+  // Tells AG-Grid how to filter EU-formatted datetimes by date
+  var filterParams = {
+    comparator: (filterLocalDateAtMidnight, cellValue) => {
+        var dateAsString = cellValue;
+        if (dateAsString == null) return -1;
+        var date = dateAsString.split(" ")
+        var dateParts = date[0].split("/");
+        var cellDate = new Date(
+        Number(dateParts[2]),
+        Number(dateParts[1]) - 1,
+        Number(dateParts[0]),
+        );
+
+        if (filterLocalDateAtMidnight.getTime() === cellDate.getTime()) {
+            return 0;
+        }
+        if (cellDate < filterLocalDateAtMidnight) {
+            return -1;
+        }
+        if (cellDate > filterLocalDateAtMidnight) {
+            return 1;
+        }
+        return 0;
+    },
+    minValidYear: 2024,
+  };
+
   const columnDefs = [
       { field: "event_id", filter: "agTextColumnFilter", headerName: "ID", flex: 1, minWidth: 100}, //  Should be enough.
       { field: "comment", filter: "agTextColumnFilter", headerName: "Comment", flex: 2, minWidth: 200 },
-      { field: "move_time", filter: "agTextColumnFilter", headerName: "Date/Time", flex: 2.0, minWidth: 170, // Enough for showing datetime
-        //formatting date right
-        valueFormatter: (params) => {
-            if (params.value) {
-              return params.value.replace('T', ' '); 
-            }
-            return params.value;
-          }
+      { field: "move_time", filter: "agDateColumnFilter", headerName: "Date/Time", flex: 2.0, minWidth: 170, filterParams:filterParams, suppressHeaderFilterButton: false,// Enough for showing datetime
       },
       { field: "loc_name", filter: "agTextColumnFilter", headerName: "Location", flex: 2.5, minWidth: 130 },
   ];
@@ -42,7 +68,7 @@ const Device_info_grid = ({ id }) => {
 
   return (
       <GridTable 
-          rowData={events.length > 0 ? events : []} 
+          rowData={formattedEvents.length > 0 ? formattedEvents : []} 
           columnDefs={columnDefs}
       />
   );

--- a/frontend/src/components/event_view_components/event_grid.jsx
+++ b/frontend/src/components/event_view_components/event_grid.jsx
@@ -23,10 +23,37 @@ const Event_grid = () => {
         return { cursor: 'pointer' };
     };
 
+    // Tells AG-Grid how to filter EU-formatted dates
+    var filterParams = {
+        comparator: (filterLocalDateAtMidnight, cellValue) => {
+            var dateAsString = cellValue;
+            if (dateAsString == null) return -1;
+            var dateParts = dateAsString.split("/");
+            var cellDate = new Date(
+            Number(dateParts[2]),
+            Number(dateParts[1]) - 1,
+            Number(dateParts[0]),
+            );
+
+            if (filterLocalDateAtMidnight.getTime() === cellDate.getTime()) {
+                return 0;
+            }
+            if (cellDate < filterLocalDateAtMidnight) {
+                return -1;
+            }
+            if (cellDate > filterLocalDateAtMidnight) {
+                return 1;
+            }
+            return 0;
+        },
+        minValidYear: 2024,
+    };
+
     const columnDefs = [
       { field: "dev_id", filter: "agTextColumnFilter", headerName: "DEV", flex: 1, minWidth: 63}, // Enough for 9999 devices
       { field: "user_id", filter: "agTextColumnFilter", headerName: "USER", flex: 1, minWidth: 63 }, // Enough for 9999 users
-      { field: "move_time", filter: "agDateColumnFilter", headerName: "Date", flex: 1.8, minWidth: 110, suppressHeaderFilterButton: false },
+      { field: "move_time", filter: "agDateColumnFilter", headerName: "Date", flex: 1.8, minWidth: 110,
+                                             filterParams: filterParams, suppressHeaderFilterButton: false },
       { field: "loc_name", filter: "agTextColumnFilter", headerName: "Location", flex: 2.0, minWidth: 130 }, // 14 characters
     ];
 


### PR DESCRIPTION
### Added custom filter to event and device_info grids to filter dates.

Currently formatting dates works as follows:
1. Import data from Endpoint as a standard Datetime (yyyy-MM-dd hh:mm:ss)
2. Format it to a string in EU-localisation (dd/MM/yyyy hh:mm:ss)
3. We have a custom filterParams telling AG-grid how to interpret the string as a Date.

This way we can display EU-format, but filter it still as a Date with AG-grid. 
Since the formatting is moved to the top of Device_info, I removed it from the columnDefs.
