### PR TITLE
Confirmation Popup 

### DIFF
--- a/frontend/src/__tests__/confirmation_popup_test.jsx
+++ b/frontend/src/__tests__/confirmation_popup_test.jsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ConfirmationPopup from '../components/device_manager/confirmation_popup';
+import '@testing-library/jest-dom'; 
+
+describe('ConfirmationPopup', () => {
+  let onConfirmMock;
+
+  beforeEach(() => {
+    onConfirmMock = jest.fn();
+  });
+
+
+  test('renders button and opens dialog on click', async () => {
+    render(
+      <ConfirmationPopup
+        renderTrigger={({ onClick }) => <button onClick={onClick}>Delete</button>}
+        onConfirm={onConfirmMock}
+        dialogTitle="Confirm Deletion"
+        dialogText="Are you sure you want to delete this device?"
+      />
+    );
+
+    const triggerButton = screen.getByText(/delete/i);
+    expect(triggerButton).toBeInTheDocument();
+
+    fireEvent.click(triggerButton);
+
+    await waitFor(() => {
+      const dialogTitle = screen.getByText(/confirm deletion/i);
+      const dialogText = screen.getByText(/are you sure you want to delete this device/i);
+      expect(dialogTitle).toBeInTheDocument();
+      expect(dialogText).toBeInTheDocument();
+    });
+  });
+
+
+  test('calls onConfirm and closes dialog on "Yes" button click', async () => {
+    render(
+      <ConfirmationPopup
+        renderTrigger={({ onClick }) => <button onClick={onClick}>Delete</button>}
+        onConfirm={onConfirmMock}
+        dialogTitle="Confirm Deletion"
+        dialogText="Are you sure you want to delete this device?"
+      />
+    );
+
+    const triggerButton = screen.getByText(/delete/i);
+    fireEvent.click(triggerButton);
+
+    const confirmButton = screen.getByText(/yes/i);
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(onConfirmMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+
+  test('closes dialog without calling onConfirm on "No" button click', async () => {
+    render(
+      <ConfirmationPopup
+        renderTrigger={({ onClick }) => <button onClick={onClick}>Delete</button>}
+        onConfirm={onConfirmMock}
+        dialogTitle="Confirm Deletion"
+        dialogText="Are you sure you want to delete this device?"
+      />
+    );
+
+    const triggerButton = screen.getByText(/delete/i);
+    fireEvent.click(triggerButton);
+
+    const noButton = screen.getByText(/no/i);
+    fireEvent.click(noButton);
+
+    await waitFor(() => {
+      expect(onConfirmMock).not.toHaveBeenCalled();
+    });
+  });
+
+
+  test('renders dialog title and text correctly', () => {
+    render(
+      <ConfirmationPopup
+        renderTrigger={({ onClick }) => <button onClick={onClick}>Delete</button>}
+        onConfirm={onConfirmMock}
+        dialogTitle="Are you sure?"
+        dialogText="This action cannot be undone."
+      />
+    );
+
+    fireEvent.click(screen.getByText(/delete/i));
+
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+  });
+
+});

--- a/frontend/src/components/device_manager/confirmation_popup.jsx
+++ b/frontend/src/components/device_manager/confirmation_popup.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -6,11 +7,11 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Function_button from '../shared/function_button';
 
-export default function ConfirmationPopup({ triggerButton, onConfirm }) {
+export default function ConfirmationPopup({ renderTrigger, onConfirm, dialogTitle, dialogText }) {
   const [open, setOpen] = React.useState(false);
 
   const handleClickOpen = (e) => {
-    e.stopPropagation(); // Prevent grid or parent events from interfering
+    e.stopPropagation();
     setOpen(true);
   };
 
@@ -25,40 +26,42 @@ export default function ConfirmationPopup({ triggerButton, onConfirm }) {
 
   return (
     <>
-      {React.cloneElement(triggerButton, { onClick: handleClickOpen })}
+      {renderTrigger({ onClick: handleClickOpen })}
       <Dialog
         open={open}
         onClose={handleClose}
         aria-labelledby="alert-dialog-title"
-        aria-describedby="confirm delete popup"
+        aria-describedby="alert-dialog-description"
       >
         <DialogTitle id="alert-dialog-title" sx={{ textAlign: 'center' }}>
-          Delete Item
+          {dialogTitle}
         </DialogTitle>
         <DialogContent>
-          <DialogContentText 
-            id="alert-dialog-description" 
+          <DialogContentText
+            id="alert-dialog-description"
             sx={{ textAlign: 'center' }}
           >
-            Are you sure?
+            {dialogText}
           </DialogContentText>
         </DialogContent>
         <DialogActions sx={{ justifyContent: 'center' }}>
-          <Function_button 
-            onClick={handleConfirm} 
-            autoFocus
-            size='medium'
-            text='Yes'
-          >
-          </Function_button>
           <Function_button
-            onClick={handleClose}
-            size='medium'
-            text='No'
-            >
-          </Function_button>
+            onClick={handleConfirm}
+            autoFocus
+            size="medium"
+            text="Yes"
+            color="error"
+          />
+          <Function_button onClick={handleClose} size="medium" text="No" />
         </DialogActions>
       </Dialog>
     </>
   );
 }
+
+ConfirmationPopup.propTypes = {
+  renderTrigger: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  dialogTitle: PropTypes.string.isRequired,
+  dialogText: PropTypes.string
+};

--- a/frontend/src/components/device_manager/confirmation_popup.jsx
+++ b/frontend/src/components/device_manager/confirmation_popup.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Function_button from '../shared/function_button';
+
+export default function ConfirmationPopup({ triggerButton, onConfirm }) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = (e) => {
+    e.stopPropagation(); // Prevent grid or parent events from interfering
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleConfirm = () => {
+    onConfirm();
+    setOpen(false);
+  };
+
+  return (
+    <>
+      {React.cloneElement(triggerButton, { onClick: handleClickOpen })}
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="confirm delete popup"
+      >
+        <DialogTitle id="alert-dialog-title" sx={{ textAlign: 'center' }}>
+          Delete Item
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText 
+            id="alert-dialog-description" 
+            sx={{ textAlign: 'center' }}
+          >
+            Are you sure?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'center' }}>
+          <Function_button 
+            onClick={handleConfirm} 
+            autoFocus
+            size='medium'
+            text='Yes'
+          >
+          </Function_button>
+          <Function_button
+            onClick={handleClose}
+            size='medium'
+            text='No'
+            >
+          </Function_button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/components/device_manager/device_manager_grid.jsx
+++ b/frontend/src/components/device_manager/device_manager_grid.jsx
@@ -15,12 +15,11 @@ const Device_manager_grid = () => {
     const { deleteData } = useDelete();
     const navigate = useNavigate(); 
 
-    // Sync updatedDevices with devices fetched from the API
     useEffect(() => {
         if (devices) {
             setDevices(devices);
         }
-    }, [devices]); // Only re-run when 'devices' changes
+    }, [devices]); 
 
     // Row sizing
     const handleRowSizing = () => {
@@ -34,16 +33,13 @@ const Device_manager_grid = () => {
 
     const handleDelete = async (rowId) => {
         const id = [{ id: rowId }];
-        // Optimistic UI: immediately remove the item from the list
         setDevices((prevDevices) => prevDevices.filter(updatedDevice => updatedDevice.dev_id !== rowId));
 
         try {
             await deleteData('devices/', id);
         } catch (error) {
             console.error(`Failed to delete device with ID: ${rowId}`, error);
-            // Rollback the optimistic update if the delete fails
             setDevices((prevDevices) => [...prevDevices, devices.find(device => device.dev_id === rowId)]);
-            // Optionally, show an error message to the user
         }
     };
 
@@ -90,7 +86,6 @@ const Device_manager_grid = () => {
 
     const getRowStyle = () => ({ cursor: 'pointer' });
 
-    // Show loading message
     if (loading) {
         return (
             <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 10vw, 2.4rem)' }}>
@@ -99,7 +94,6 @@ const Device_manager_grid = () => {
         );
     }
 
-    // Show error message
     if (error) {
         return (
             <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 9vw, 2.4rem)', color: 'red' }}>

--- a/frontend/src/components/device_manager/device_manager_grid.jsx
+++ b/frontend/src/components/device_manager/device_manager_grid.jsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import GridTable from '../shared/grid_table.jsx';
 import Typography from '@mui/material/Typography';
 import Function_button from '../shared/function_button.jsx';
+import ConfirmationPopup from './confirmation_popup.jsx';
 import useFetchData from '../shared/fetch_data';
 import useDelete from '../shared/delete_data.jsx';
 import { useNavigate } from 'react-router-dom';
@@ -56,7 +57,16 @@ const Device_manager_grid = () => {
                 return (
                     <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                         <Function_button text='Modify' onClick={() => handleModify(devId)}></Function_button>
-                        <Function_button text='Delete' color='error' onClick={() => handleDelete(devId)}></Function_button>
+                        <ConfirmationPopup
+                            triggerButton={
+                                <Function_button
+                                    text="Delete"
+                                    color="error"
+                                    onClick={(e) => e.stopPropagation()}
+                                />
+                            }
+                            onConfirm={() => handleDelete(devId)}
+                        />
                     </div>
                 );
             },

--- a/frontend/src/components/device_manager/device_manager_grid.jsx
+++ b/frontend/src/components/device_manager/device_manager_grid.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState, useEffect } from 'react';
 import GridTable from '../shared/grid_table.jsx';
 import Typography from '@mui/material/Typography';
 import Function_button from '../shared/function_button.jsx';
@@ -9,45 +9,48 @@ import { useNavigate } from 'react-router-dom';
 
 const Device_manager_grid = () => {
     const { data: devices, loading, error } = useFetchData('devices/');
+    const [updatedDevices, setDevices] = useState([]);
     const [cellHeight, setCellHeight] = useState(false);
     const [whiteSpace, setWhiteSpace] = useState('');
-    const { deleteData} = useDelete();
+    const { deleteData } = useDelete();
     const navigate = useNavigate(); 
 
-    //Row sizing
+    // Sync updatedDevices with devices fetched from the API
+    useEffect(() => {
+        if (devices) {
+            setDevices(devices);
+        }
+    }, [devices]); // Only re-run when 'devices' changes
+
+    // Row sizing
     const handleRowSizing = () => {
-        if(!cellHeight) {        
-            setWhiteSpace('normal')
-        }
-        else {
-            setWhiteSpace('')
-        }
-        setCellHeight(!cellHeight);
-    }   
+        setCellHeight(prev => !prev);
+        setWhiteSpace(prev => (prev === '' ? 'normal' : ''));
+    };
 
     const handleModify = (rowId) => {
         navigate('/devices/' + rowId + '/edit');
-;
     };
-    
-    const handleDelete = async(rowId) => {
-        
+
+    const handleDelete = async (rowId) => {
         const id = [{ id: rowId }];
-        
+        // Optimistic UI: immediately remove the item from the list
+        setDevices((prevDevices) => prevDevices.filter(updatedDevice => updatedDevice.dev_id !== rowId));
+
         try {
-            await deleteData('devices/', id); 
-            navigate('/admin');
+            await deleteData('devices/', id);
         } catch (error) {
             console.error(`Failed to delete device with ID: ${rowId}`, error);
+            // Rollback the optimistic update if the delete fails
+            setDevices((prevDevices) => [...prevDevices, devices.find(device => device.dev_id === rowId)]);
+            // Optionally, show an error message to the user
         }
-        
     };
 
     const columnDefs = [
-        
-        { field: "dev_name", filter: "agTextColumnFilter", headerName: "Device", flex: 2,  minWidth: 120, autoHeight: cellHeight, sort: 'asc',
-            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word',  lineHeight: 1.2,  paddingTop: '13px', } // text wrapping
-            }, // Important, 34 characters
+        { field: "dev_name", filter: "agTextColumnFilter", headerName: "Device", flex: 2, minWidth: 120, autoHeight: cellHeight, sort: 'asc',
+            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word', lineHeight: 1.2, paddingTop: '13px' }
+        },
         {
             headerName: "Actions",
             field: "actions",
@@ -56,16 +59,18 @@ const Device_manager_grid = () => {
                 const devId = params.data.dev_id;
                 return (
                     <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                        <Function_button text='Modify' onClick={() => handleModify(devId)}></Function_button>
+                        <Function_button text='Modify' onClick={() => handleModify(devId)} />
                         <ConfirmationPopup
-                            triggerButton={
+                            renderTrigger={({ onClick }) => (
                                 <Function_button
                                     text="Delete"
                                     color="error"
-                                    onClick={(e) => e.stopPropagation()}
+                                    onClick={onClick}
                                 />
-                            }
+                            )}
                             onConfirm={() => handleDelete(devId)}
+                            dialogTitle="Delete Item"
+                            dialogText="Are you sure?"
                         />
                     </div>
                 );
@@ -73,21 +78,19 @@ const Device_manager_grid = () => {
             cellStyle: { display: 'flex', justifyContent: 'space-between', paddingTop: '13px' },
         },
         { field: "dev_manufacturer", filter: "agTextColumnFilter", headerName: "Manufacturer", flex: 0.5, minWidth: 120, autoHeight: cellHeight,
-             cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word',  lineHeight: 1.2,  paddingTop: '13px', } // text wrapping
-            }, // Enough for 9999 devices
+            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word', lineHeight: 1.2, paddingTop: '13px' }
+        },
         { field: "dev_model", filter: "agTextColumnFilter", headerName: "Model", flex: 1.4, minWidth: 100, autoHeight: cellHeight,
-            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word',  lineHeight: 1.2,  paddingTop: '13px', } // text wrapping
-        }, // Not as important, 14 characters
+            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word', lineHeight: 1.2, paddingTop: '13px' }
+        },
         { field: "class_name", filter: "agTextColumnFilter", headerName: "Class", flex: 2, minWidth: 120, autoHeight: cellHeight,
-            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word',  lineHeight: 1.2,  paddingTop: '13px', } // text wrapping
-            },
+            cellStyle: { whiteSpace: whiteSpace, wordWrap: 'break-word', lineHeight: 1.2, paddingTop: '13px' }
+        },
     ];
 
-    const getRowStyle = () => {
-        return { cursor: 'pointer' };
-    };
+    const getRowStyle = () => ({ cursor: 'pointer' });
 
-
+    // Show loading message
     if (loading) {
         return (
             <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 10vw, 2.4rem)' }}>
@@ -96,6 +99,7 @@ const Device_manager_grid = () => {
         );
     }
 
+    // Show error message
     if (error) {
         return (
             <Typography sx={{ mt: 7, fontSize: 'clamp(1.5rem, 9vw, 2.4rem)', color: 'red' }}>
@@ -107,19 +111,17 @@ const Device_manager_grid = () => {
 
     return (
         <div>
-        <Function_button
-        size='small'
-        text= {!cellHeight ? 'Expand rows' : 'Collapse rows'}
-        onClick={handleRowSizing}
-        />     
-        <GridTable 
-            rowData={devices} 
-            columnDefs={columnDefs}
-            getRowStyle={getRowStyle}
-            /*getRowStyle={getRowStyle}*/
-        />
+            <Function_button
+                size='small'
+                text={!cellHeight ? 'Expand rows' : 'Collapse rows'}
+                onClick={handleRowSizing}
+            />
+            <GridTable 
+                rowData={updatedDevices} 
+                columnDefs={columnDefs}
+                getRowStyle={getRowStyle}
+            />
         </div>
-
     );
 };
 


### PR DESCRIPTION
### Added Confirmation Popup and Unit Tests for it, Modified Device Manager Grid to use it

- Confirmation Popup asks user to double verify they want to do something. (Yes/No)
- Prompt is customisable with Dialog Title/Text, making it reusable.
- Updated Device Manager to use it when Deleting Devices
- Deleting a device now 'hot' updates the grid and doesn't redirect from the page

Closes #127 