### PR TITLE
Sign out button

### DIFF
--- a/frontend/src/__tests__/sign_out_button_test.jsx
+++ b/frontend/src/__tests__/sign_out_button_test.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SignoutButton from "../components/shared/sign_out_button";
+import '@testing-library/jest-dom';
+
+describe("SignoutButton", () => {
+
+  const mockAuth = { msg: "Authorized" };
+
+  beforeEach(() => {
+    Storage.prototype.removeItem = jest.fn(); // eslint-disable-line no-undef
+  
+    delete window.location;
+    window.location = {
+      href: "",
+      pathname: "/admin",
+      reload: jest.fn(),
+    };
+  });
+  
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  
+  test("renders the SignoutButton if user is authorized", () => {
+    render(<SignoutButton auth={mockAuth} />);
+    const button = screen.getByText("Sign Out");
+    expect(button).toBeInTheDocument();
+  });
+
+  test("does not render the SignoutButton if user is unauthorized", () => {
+    render(<SignoutButton auth={{ msg: "Unauthorized" }} />);
+    const button = screen.queryByText("Sign Out");
+    expect(button).not.toBeInTheDocument();
+  });
+
+  test("removes the access token and reloads on non-admin pages", () => {
+    window.location.pathname = "/not_admin";
+    render(<SignoutButton auth={mockAuth} />);
+    const button = screen.getByText("Sign Out");
+
+    fireEvent.click(button);
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith("access_token");
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  test("removes the access token and redirects to device register on admin pages", () => {
+    window.location.pathname = "/admin";
+    render(<SignoutButton auth={mockAuth} />);
+    const button = screen.getByText("Sign Out");
+
+    fireEvent.click(button);
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith("access_token");
+    expect(window.location.href).toBe("/");
+  });
+
+  test("does not throw an error if button is clicked without an auth object", () => {
+    render(<SignoutButton auth={{ error: "Unauthorized" }} />);
+    const button = screen.queryByText("Sign Out");
+    expect(button).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/device_manager/confirmation_popup.jsx
+++ b/frontend/src/components/device_manager/confirmation_popup.jsx
@@ -5,7 +5,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import Function_button from '../shared/Function_button';
+import Function_button from '../shared/function_button';
 
 const ConfirmationPopup = forwardRef(({ renderTrigger, onConfirm, dialogTitle, dialogText }, ref) => {
   const [open, setOpen] = useState(false);

--- a/frontend/src/components/device_manager/confirmation_popup.jsx
+++ b/frontend/src/components/device_manager/confirmation_popup.jsx
@@ -5,7 +5,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import Function_button from '../shared/function_button';
+import Function_button from '../shared/Function_button';
 
 const ConfirmationPopup = forwardRef(({ renderTrigger, onConfirm, dialogTitle, dialogText }, ref) => {
   const [open, setOpen] = useState(false);

--- a/frontend/src/components/device_manager/device_manager_grid.jsx
+++ b/frontend/src/components/device_manager/device_manager_grid.jsx
@@ -1,17 +1,15 @@
 import React, { useState, useEffect, useRef } from 'react';
 import GridTable from '../shared/grid_table.jsx';
 import Typography from '@mui/material/Typography';
-import Function_button from '../shared/function_button.jsx';
+import Function_button from '../shared/Function_button.jsx';
 import ConfirmationPopup from './confirmation_popup.jsx';
 import useFetchData from '../shared/fetch_data';
 import useDelete from '../shared/delete_data.jsx';
-import { useNavigate } from 'react-router-dom';
 
 const Device_manager_grid = () => {
     const { data: devices, loading, error } = useFetchData('devices/');
     const [updatedDevices, setDevices] = useState([]);
     const { deleteData } = useDelete();
-    const navigate = useNavigate();
     const popupRef = useRef(null);
     const [expandAll, setExpandAll] = useState(false);
 
@@ -54,7 +52,7 @@ const Device_manager_grid = () => {
     };
 
     const handleModify = (rowId) => {
-        navigate(`/devices/${rowId}/edit`);
+        window.location.href = `/devices/${rowId}/edit`;
     };
 
     const handleDelete = async (rowId) => {

--- a/frontend/src/components/device_manager/device_manager_grid.jsx
+++ b/frontend/src/components/device_manager/device_manager_grid.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import GridTable from '../shared/grid_table.jsx';
 import Typography from '@mui/material/Typography';
-import Function_button from '../shared/Function_button.jsx';
+import Function_button from '../shared/function_button.jsx';
 import ConfirmationPopup from './confirmation_popup.jsx';
 import useFetchData from '../shared/fetch_data';
 import useDelete from '../shared/delete_data.jsx';

--- a/frontend/src/components/shared/sign_out_button.jsx
+++ b/frontend/src/components/shared/sign_out_button.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Function_button from "./Function_button";
+import Function_button from "./function_button";
 
 const SignoutButton = ({ auth }) => {
 

--- a/frontend/src/components/shared/sign_out_button.jsx
+++ b/frontend/src/components/shared/sign_out_button.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Function_button from "./Function_button";
+
+const SignoutButton = ({ auth }) => {
+
+  const handleSignout = () => {
+    localStorage.removeItem("access_token");
+    const isAdminView = window.location.pathname.startsWith("/admin") 
+                    || window.location.pathname.startsWith("/events"); 
+
+    if (isAdminView) {
+      window.location.href = "/";
+    } else {
+      window.location.reload();
+    }
+  };
+
+  if (!auth || auth.msg !== "Authorized") return null;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 5,
+        right: 17,
+      }}
+    >
+      <Function_button
+        text="Sign Out"
+        onClick={handleSignout}
+        color="primary"
+        variant="contained"
+        size="small"
+      />
+    </div>
+  );
+};
+
+SignoutButton.propTypes = {
+  auth: PropTypes.shape({
+    msg: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default SignoutButton;

--- a/frontend/src/views/add_view.jsx
+++ b/frontend/src/views/add_view.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import { Typography, TextField, MenuItem, Select, FormControl, InputLabel  } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/Function_button';
+import Function_button from '../components/shared/function_button';
 import {useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import useFetchData from '../components/shared/fetch_data';

--- a/frontend/src/views/add_view.jsx
+++ b/frontend/src/views/add_view.jsx
@@ -3,13 +3,16 @@ import Box from '@mui/material/Box';
 import { Typography, TextField, MenuItem, Select, FormControl, InputLabel  } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/function_button';
+import Function_button from '../components/shared/Function_button';
 import {useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import useFetchData from '../components/shared/fetch_data';
 import usePostData from '../components/shared/post_data';
+import SignoutButton from '../components/shared/sign_out_button';
+
 const Add_view = () => {
   const navigate = useNavigate(); 
+  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
   const { data: deviceClasses, loading} = useFetchData('classes/');
   const [errorMessage, setErrorMessage] = useState(null);
   
@@ -90,6 +93,7 @@ const Add_view = () => {
         gap: 2
     }}>
           <NavigationBar/>
+          {!authloading && auth && !authError && <SignoutButton auth={auth} />}
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',

--- a/frontend/src/views/admin_view.jsx
+++ b/frontend/src/views/admin_view.jsx
@@ -3,9 +3,10 @@ import Box from '@mui/material/Box';
 import { Typography } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Link_button from '../components/shared/link_button';
-import Function_button from '../components/shared/function_button';
+import Function_button from '../components/shared/Function_button';
 import { config } from '../utils/config';
 import useFetchData from "../components/shared/fetch_data";
+import SignoutButton from '../components/shared/sign_out_button';
 
 function Admin_view() {
   const { data: auth, loading: authLoading, error: authError } = useFetchData('auth/admin');
@@ -82,6 +83,7 @@ function Admin_view() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
       <NavigationBar />
+      {!authLoading && auth && !authError && <SignoutButton auth={auth} />}
       <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', mt: 8 }}>Management pages</Typography>
       <Link_button href={`/admin/manager`} text="Devices" />
       <Link_button href={`/events`} text="Events" />

--- a/frontend/src/views/admin_view.jsx
+++ b/frontend/src/views/admin_view.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import { Typography } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Link_button from '../components/shared/link_button';
-import Function_button from '../components/shared/Function_button';
+import Function_button from '../components/shared/function_button';
 import { config } from '../utils/config';
 import useFetchData from "../components/shared/fetch_data";
 import SignoutButton from '../components/shared/sign_out_button';

--- a/frontend/src/views/device_info_view.jsx
+++ b/frontend/src/views/device_info_view.jsx
@@ -7,14 +7,13 @@ import Link_button from '../components/shared/link_button';
 import { useParams } from 'react-router-dom';
 import useFetchData from '../components/shared/fetch_data';
 import { config } from '../utils/config';
+import SignoutButton from '../components/shared/sign_out_button';
 
 const Device_info_view = () => {
   const { id } = useParams();
-
+  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
   const { data: device, error } = useFetchData('devices/' + id);
   const { data: locations} = useFetchData('devices/current_locations/');
-
-  
 
   const devName = String(device.dev_name);
   const devClass = String(device.class_name);
@@ -48,7 +47,7 @@ const Device_info_view = () => {
       gap: 2
   }}>
         <NavigationBar/>
-
+        {!authloading && auth && !authError && <SignoutButton auth={auth} />}
         <Device_description devName={devName} devLocation={devLoc} devClass={devClass}
          devModel={devModel} devManufacturer={devManufacturer} devComments={devComments} error={error}/>
         

--- a/frontend/src/views/device_manager_view.jsx
+++ b/frontend/src/views/device_manager_view.jsx
@@ -5,6 +5,7 @@ import NavigationBar from '../components/shared/navigation_bar';
 import Link_button from '../components/shared/link_button';
 import Device_manager_grid from '../components/device_manager/device_manager_grid';
 import useFetchData from '../components/shared/fetch_data';
+import SignoutButton from '../components/shared/sign_out_button';
 
 function Device_manager_view() {
 
@@ -41,6 +42,7 @@ function Device_manager_view() {
         gap: 4 
       }}>
         <NavigationBar/>
+        {!loading && auth && !error && <SignoutButton auth={auth} />}
         <Typography sx={{ fontSize: 'clamp(2.4rem, 3vw, 1.8rem)', mt: 8 }}>
           Device manager
         </Typography>

--- a/frontend/src/views/device_register_view.jsx
+++ b/frontend/src/views/device_register_view.jsx
@@ -4,10 +4,14 @@ import { Typography } from '@mui/material';
 import DeviceGrid from '../components/device_register/device_register_grid';
 import NavigationBar from '../components/shared/navigation_bar';
 import Link_button from '../components/shared/link_button';
+import SignoutButton from '../components/shared/sign_out_button';
+import useFetchData from '../components/shared/fetch_data';
 import { config } from '../utils/config';
 
 
 function Device_register_view() {
+
+  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
 
   return (
     <Box sx={{
@@ -21,6 +25,7 @@ function Device_register_view() {
         textWrap: 'nowrap'
     }}>
         <NavigationBar/>
+        {!authloading && auth && !authError && <SignoutButton auth={auth} />}
         <Box sx={{
           display: 'flex',
           flexDirection: 'row',

--- a/frontend/src/views/edit_view.jsx
+++ b/frontend/src/views/edit_view.jsx
@@ -3,16 +3,18 @@ import Box from '@mui/material/Box';
 import { Typography, TextField, MenuItem, Select, FormControl, InputLabel  } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/function_button';
+import Function_button from '../components/shared/Function_button';
 import Link_button from '../components/shared/link_button';
 import {useParams, useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import useFetchData from '../components/shared/fetch_data';
+import SignoutButton from '../components/shared/sign_out_button';
 import usePatch from '../components/shared/patch_data';
+
 const Edit_view = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-  const {data: auth, error} = useFetchData('auth/admin');
+  const {data: auth, loading: authLoading, error: error} = useFetchData('auth/admin');
   const { data: deviceClasses} = useFetchData('classes/');
   const { data: device, loading} = useFetchData('devices/'+id);
   const [errorMessage, setErrorMessage] = useState(null);
@@ -117,6 +119,7 @@ const Edit_view = () => {
         gap: 2
     }}>
           <NavigationBar/>
+          {!authLoading && auth && !error && <SignoutButton auth={auth} />}
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',

--- a/frontend/src/views/edit_view.jsx
+++ b/frontend/src/views/edit_view.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import { Typography, TextField, MenuItem, Select, FormControl, InputLabel  } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/Function_button';
+import Function_button from '../components/shared/function_button';
 import Link_button from '../components/shared/link_button';
 import {useParams, useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';

--- a/frontend/src/views/event_view.jsx
+++ b/frontend/src/views/event_view.jsx
@@ -4,6 +4,7 @@ import NavigationBar from '../components/shared/navigation_bar';
 import EventGrid from '../components/event_view_components/event_grid';
 import { Typography,  } from '@mui/material';
 import useFetchData from '../components/shared/fetch_data';
+import SignoutButton from '../components/shared/sign_out_button';
 
 function Event_view() {
   const {data: auth, loading, error} = useFetchData('auth/admin');
@@ -42,6 +43,7 @@ function Event_view() {
         textWrap: 'nowrap'
     }}>
         <NavigationBar/>
+        {!loading && auth && !error && <SignoutButton auth={auth} />}
         <Typography sx={{
           fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
           textAlign: 'center',

--- a/frontend/src/views/login_view.jsx
+++ b/frontend/src/views/login_view.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import { Typography, TextField } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/Function_button';
+import Function_button from '../components/shared/function_button';
 import {useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import usePostData from '../components/shared/post_data';

--- a/frontend/src/views/login_view.jsx
+++ b/frontend/src/views/login_view.jsx
@@ -3,10 +3,11 @@ import Box from '@mui/material/Box';
 import { Typography, TextField } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/function_button';
+import Function_button from '../components/shared/Function_button';
 import {useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import usePostData from '../components/shared/post_data';
+
 const Login_view = () => {
 
   const navigate = useNavigate();

--- a/frontend/src/views/move_view.jsx
+++ b/frontend/src/views/move_view.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import { Typography, TextField } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/Function_button';
+import Function_button from '../components/shared/function_button';
 import { useParams, useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import useFetchData from '../components/shared/fetch_data';

--- a/frontend/src/views/move_view.jsx
+++ b/frontend/src/views/move_view.jsx
@@ -3,14 +3,17 @@ import Box from '@mui/material/Box';
 import { Typography, TextField } from '@mui/material';
 import NavigationBar from '../components/shared/navigation_bar';
 import Form_container from '../components/shared/form_container';
-import Function_button from '../components/shared/function_button';
+import Function_button from '../components/shared/Function_button';
 import { useParams, useNavigate} from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import useFetchData from '../components/shared/fetch_data';
 import usePostData from '../components/shared/post_data';
+import SignoutButton from '../components/shared/sign_out_button';
+
 const Move_view = () => {
   const { id } = useParams();
   const navigate = useNavigate(); 
+  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
   const { data: device, loading, error } = useFetchData('devices/' + id);
   const [errorMessage, setErrorMessage] = useState(null);
   const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -120,6 +123,7 @@ const Move_view = () => {
         gap: 2
     }}>
           <NavigationBar/>
+          {!authloading && auth && !authError && <SignoutButton auth={auth} />}
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',


### PR DESCRIPTION
### Sign out button

Added a Sign out button that is visible in relevant views if the user is logged in as an admin, and unit tests for it.

* Button is anchored to top right corner. The current solution is not at the direct edge because of potential scroll bars that might obstruct it. If needed a more intricate solution is probably possible.
* If clicked in a restricted view, it deletes the access token and sends the user to the main page (Device register, "/")
* If clicked in an unrestricted view, it deletes the token and reloads the page.
* Added the button to all views where it makes sense, along with a simple condition to wait for the fetched auth to load to prevent timing errors.

* Small tweak to Device Manager Grid to not use Navigate() as it isn't wrapped in a router directly.

Closes #238  