### PR TITLE
Nav bar and Signout  check local_storage instead of API

### DIFF
--- a/frontend/src/__tests__/navigation_bar_test.jsx
+++ b/frontend/src/__tests__/navigation_bar_test.jsx
@@ -4,23 +4,32 @@ import '@testing-library/jest-dom/';
 import NavigationBar from '../components/shared/navigation_bar';
 
 describe("NavigationBar Component", () => {
-
-  test("Renders navigation bar with locked admin access when not authorized", () => {
-    const mockAuth = { msg: "Unauthorized" };
-
-    render(<NavigationBar auth={mockAuth} />);
-
-    expect(screen.getByLabelText('Home')).toBeInTheDocument();
-    expect(screen.getByLabelText('Admin Login')).toBeInTheDocument();
+  beforeEach(() => {
+    // Mock localStorage methods
+    Storage.prototype.getItem = jest.fn();  // eslint-disable-line no-undef
   });
 
-  test("Renders navigation bar with open admin access when authorized", () => {
-    const mockAuth = { msg: "Authorized" };
-
-    render(<NavigationBar auth={mockAuth} />);
-
-    expect(screen.getByLabelText('Home')).toBeInTheDocument();
-    expect(screen.getByLabelText('Admin Panel')).toBeInTheDocument();
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
+  test("Renders navigation bar with locked admin access when not authenticated", () => {
+    localStorage.getItem.mockReturnValue(null); 
+
+    render(<NavigationBar />);
+
+    expect(screen.getByLabelText('Home')).toBeInTheDocument();
+    expect(screen.getByLabelText('Admin Login')).toBeInTheDocument(); 
+    expect(screen.queryByLabelText('Admin Panel')).not.toBeInTheDocument();
+  });
+
+  test("Renders navigation bar with open admin access when authenticated", () => {
+    localStorage.getItem.mockReturnValue("fake_token"); 
+
+    render(<NavigationBar />);
+
+    expect(screen.getByLabelText('Home')).toBeInTheDocument();
+    expect(screen.getByLabelText('Admin Panel')).toBeInTheDocument(); 
+    expect(screen.queryByLabelText('Admin Login')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/sign_out_button_test.jsx
+++ b/frontend/src/__tests__/sign_out_button_test.jsx
@@ -1,15 +1,13 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import SignoutButton from "../components/shared/sign_out_button";
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
 
 describe("SignoutButton", () => {
-
-  const mockAuth = { msg: "Authorized" };
-
   beforeEach(() => {
-    Storage.prototype.removeItem = jest.fn(); // eslint-disable-line no-undef
-  
+    Storage.prototype.getItem = jest.fn();  // eslint-disable-line no-undef
+    Storage.prototype.removeItem = jest.fn();  // eslint-disable-line no-undef
+
     delete window.location;
     window.location = {
       href: "",
@@ -17,26 +15,29 @@ describe("SignoutButton", () => {
       reload: jest.fn(),
     };
   });
-  
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
-  
-  test("renders the SignoutButton if user is authorized", () => {
-    render(<SignoutButton auth={mockAuth} />);
+
+  test("renders the SignoutButton if access token exists", () => {
+    localStorage.getItem.mockReturnValue("fake_token"); 
+    render(<SignoutButton />);
     const button = screen.getByText("Sign Out");
     expect(button).toBeInTheDocument();
   });
 
-  test("does not render the SignoutButton if user is unauthorized", () => {
-    render(<SignoutButton auth={{ msg: "Unauthorized" }} />);
+  test("does not render the SignoutButton if no access token exists", () => {
+    localStorage.getItem.mockReturnValue(null); 
+    render(<SignoutButton />);
     const button = screen.queryByText("Sign Out");
     expect(button).not.toBeInTheDocument();
   });
 
   test("removes the access token and reloads on non-admin pages", () => {
+    localStorage.getItem.mockReturnValue("fake_token");
     window.location.pathname = "/not_admin";
-    render(<SignoutButton auth={mockAuth} />);
+    render(<SignoutButton />);
     const button = screen.getByText("Sign Out");
 
     fireEvent.click(button);
@@ -45,9 +46,10 @@ describe("SignoutButton", () => {
     expect(window.location.reload).toHaveBeenCalled();
   });
 
-  test("removes the access token and redirects to device register on admin pages", () => {
+  test("removes the access token and redirects to home on admin pages", () => {
+    localStorage.getItem.mockReturnValue("fake_token");
     window.location.pathname = "/admin";
-    render(<SignoutButton auth={mockAuth} />);
+    render(<SignoutButton />);
     const button = screen.getByText("Sign Out");
 
     fireEvent.click(button);
@@ -56,8 +58,9 @@ describe("SignoutButton", () => {
     expect(window.location.href).toBe("/");
   });
 
-  test("does not throw an error if button is clicked without an auth object", () => {
-    render(<SignoutButton auth={{ error: "Unauthorized" }} />);
+  test("does not render if there is no access token and ensures no errors occur", () => {
+    localStorage.getItem.mockReturnValue(null);
+    render(<SignoutButton />);
     const button = screen.queryByText("Sign Out");
     expect(button).not.toBeInTheDocument();
   });

--- a/frontend/src/components/shared/navigation_bar.jsx
+++ b/frontend/src/components/shared/navigation_bar.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import PropTypes from "prop-types";
+import {React, useState} from 'react';
 import Grid2 from '@mui/material/Grid2';
 import LinkButton from './link_button';
 import { Home, Lock, LockOpen } from '@mui/icons-material';
 
-const Navigation_bar = ({ auth }) => {
+const Navigation_bar = () => {
   // Determine the appropriate icon based on authentication status
-  const adminIcon = auth && auth.msg === "Authorized" ? <LockOpen aria-label="Admin Panel"/> : <Lock aria-label="Admin Login"/>;
+  const [isAuthenticated] = useState(() => {
+    const token = localStorage.getItem("access_token");
+    return token !== null;
+  });
+
+  const adminIcon = isAuthenticated ? <LockOpen aria-label="Admin Panel"/> : <Lock aria-label="Admin Login"/>;
 
   return (
     <Grid2
@@ -49,12 +53,6 @@ const Navigation_bar = ({ auth }) => {
       />
     </Grid2>
   );
-};
-
-Navigation_bar.propTypes = {
-  auth: PropTypes.shape({
-    msg: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 export default Navigation_bar;

--- a/frontend/src/components/shared/sign_out_button.jsx
+++ b/frontend/src/components/shared/sign_out_button.jsx
@@ -1,8 +1,12 @@
-import React from "react";
-import PropTypes from "prop-types";
+import {React, useState} from "react";
 import Function_button from "./function_button";
 
-const SignoutButton = ({ auth }) => {
+const SignoutButton = () => {
+
+  const [isAuthenticated] = useState(() => {
+    const token = localStorage.getItem("access_token");
+    return token !== null;
+  });
 
   const handleSignout = () => {
     localStorage.removeItem("access_token");
@@ -16,7 +20,7 @@ const SignoutButton = ({ auth }) => {
     }
   };
 
-  if (!auth || auth.msg !== "Authorized") return null;
+  if (!isAuthenticated) return null;
 
   return (
     <div
@@ -35,12 +39,6 @@ const SignoutButton = ({ auth }) => {
       />
     </div>
   );
-};
-
-SignoutButton.propTypes = {
-  auth: PropTypes.shape({
-    msg: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 export default SignoutButton;

--- a/frontend/src/views/add_view.jsx
+++ b/frontend/src/views/add_view.jsx
@@ -13,7 +13,6 @@ import { config } from '../utils/config';
 
 const Add_view = () => {
   const navigate = useNavigate(); 
-  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
   const { data: deviceClasses, loading} = useFetchData('classes/');
   const [errorMessage, setErrorMessage] = useState(null);
   const [selectedFile, setSelectedFile] = useState(null);
@@ -147,8 +146,8 @@ const Add_view = () => {
         textWrap: 'nowrap',
         gap: 2
     }}>
-          <NavigationBar auth={auth} />
-          {!authloading && auth && !authError && <SignoutButton auth={auth} />}
+          <NavigationBar/>
+          <SignoutButton />
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',

--- a/frontend/src/views/admin_view.jsx
+++ b/frontend/src/views/admin_view.jsx
@@ -71,7 +71,7 @@ function Admin_view() {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center',
         alignItems: 'center', height: '100vh', textAlign: 'center' }}>
-        <NavigationBar auth={auth} />
+        <NavigationBar/>
         <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', mb: 2 }}>
           You must be logged in to view this content.
         </Typography>
@@ -82,8 +82,8 @@ function Admin_view() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
-      <NavigationBar auth={auth} />
-      {!authLoading && auth && !authError && <SignoutButton auth={auth} />}
+      <NavigationBar/>
+      <SignoutButton />
       <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', mt: 8 }}>Management pages</Typography>
       <Link_button href={`/admin/manager`} text="Devices" />
       <Link_button href={`/events`} text="Events" />

--- a/frontend/src/views/class_view.jsx
+++ b/frontend/src/views/class_view.jsx
@@ -13,7 +13,7 @@ import useDelete from '../components/shared/delete_data';
 
 const Class_view = () => {
   const { deleteData: deleteData} = useDelete();
-  const {data: auth, loading: authLoading, error: error} = useFetchData('auth/admin');
+  const {data: auth, error: error} = useFetchData('auth/admin');
   const { data: deviceClasses, loading} = useFetchData('classes/');
   const [errorMessage, setErrorMessage] = useState(null);
 
@@ -96,7 +96,7 @@ const Class_view = () => {
   if (error || !auth || auth.msg != 'Authorized') { 
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100vh', textAlign: 'center' }}>
-        <NavigationBar auth={auth} />
+        <NavigationBar/>
         <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', mb: 2 }}>
           You must be logged in to view this content.
         </Typography>
@@ -118,8 +118,8 @@ const Class_view = () => {
         textWrap: 'nowrap',
         gap: 2
     }}>
-          <NavigationBar auth={auth} />
-          {!authLoading && auth && !error && <SignoutButton auth={auth} />}
+          <NavigationBar/>
+          <SignoutButton />
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',

--- a/frontend/src/views/device_info_view.jsx
+++ b/frontend/src/views/device_info_view.jsx
@@ -13,7 +13,6 @@ import SignoutButton from '../components/shared/sign_out_button';
 
 const Device_info_view = () => {
   const { id } = useParams();
-  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
   const { data: device, error } = useFetchData('devices/' + id);
   const { data: locations} = useFetchData('devices/current_locations/');
 
@@ -49,8 +48,8 @@ const Device_info_view = () => {
       textWrap: 'nowrap',
       gap: 2
   }}>
-        <NavigationBar auth={auth} />
-        {!authloading && auth && !authError && <SignoutButton auth={auth} />}
+        <NavigationBar/>
+        <SignoutButton />
         <Device_description devName={devName} devLocation={devLoc} devClass={devClass}
          devModel={devModel} devManufacturer={devManufacturer} devComments={devComments} devHome={devHome} error={error}/>
         

--- a/frontend/src/views/device_manager_view.jsx
+++ b/frontend/src/views/device_manager_view.jsx
@@ -25,7 +25,7 @@ function Device_manager_view() {
   if (error || !auth || auth.msg != 'Authorized') { 
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100vh', textAlign: 'center' }}>
-        <NavigationBar auth={auth} />
+        <NavigationBar/>
         <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', mb: 2 }}>
           You must be logged in to view this content.
         </Typography>
@@ -41,8 +41,8 @@ function Device_manager_view() {
         alignItems: 'center',
         gap: 4 
       }}>
-        <NavigationBar auth={auth} />
-        {!loading && auth && !error && <SignoutButton auth={auth} />}
+        <NavigationBar/>
+        <SignoutButton />
         <Typography sx={{ fontSize: 'clamp(2.4rem, 3vw, 1.8rem)', mt: 8 }}>
           Device manager
         </Typography>

--- a/frontend/src/views/device_register_view.jsx
+++ b/frontend/src/views/device_register_view.jsx
@@ -5,13 +5,10 @@ import DeviceGrid from '../components/device_register/device_register_grid';
 import NavigationBar from '../components/shared/navigation_bar';
 import Link_button from '../components/shared/link_button';
 import SignoutButton from '../components/shared/sign_out_button';
-import useFetchData from '../components/shared/fetch_data';
 import { config } from '../utils/config';
 
 
 function Device_register_view() {
-
-  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
 
   return (
     <Box sx={{
@@ -24,8 +21,8 @@ function Device_register_view() {
         overflow: 'hidden',
         textWrap: 'nowrap'
     }}>
-        <NavigationBar auth={auth} />
-        {!authloading && auth && !authError && <SignoutButton auth={auth} />}
+        <NavigationBar/>
+        <SignoutButton />
         <Box sx={{
           display: 'flex',
           flexDirection: 'row',

--- a/frontend/src/views/edit_view.jsx
+++ b/frontend/src/views/edit_view.jsx
@@ -15,7 +15,7 @@ import usePatch from '../components/shared/patch_data';
 const Edit_view = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-  const {data: auth, loading: authLoading, error: error} = useFetchData('auth/admin');
+  const {data: auth, error: error} = useFetchData('auth/admin');
   const { data: deviceClasses} = useFetchData('classes/');
   const { data: device, loading} = useFetchData('devices/'+id);
   const [errorMessage, setErrorMessage] = useState(null);
@@ -97,7 +97,7 @@ const Edit_view = () => {
   if (error || !auth || auth.msg != 'Authorized') { 
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100vh', textAlign: 'center' }}>
-        <NavigationBar auth={auth} />
+        <NavigationBar/>
         <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', mb: 2 }}>
           You must be logged in to view this content.
         </Typography>
@@ -119,8 +119,8 @@ const Edit_view = () => {
         textWrap: 'nowrap',
         gap: 2
     }}>
-          <NavigationBar auth={auth} />
-          {!authLoading && auth && !error && <SignoutButton auth={auth} />}
+          <NavigationBar/>
+          <SignoutButton />
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',

--- a/frontend/src/views/event_view.jsx
+++ b/frontend/src/views/event_view.jsx
@@ -23,7 +23,7 @@ function Event_view() {
   if (error || auth.msg != 'Authorized' ) { 
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', textAlign: 'center' }}>
-        <NavigationBar auth={auth} />
+        <NavigationBar/>
         <Typography sx={{ fontSize: 'clamp(1.2rem, 3vw, 1.8rem)' }}>
           You must be logged in to view this content.
         </Typography>
@@ -42,8 +42,8 @@ function Event_view() {
         overflow: 'hidden',
         textWrap: 'nowrap'
     }}>
-        <NavigationBar auth={auth} />
-        {!loading && auth && !error && <SignoutButton auth={auth} />}
+        <NavigationBar/>
+        <SignoutButton />
         <Typography sx={{
           fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
           textAlign: 'center',

--- a/frontend/src/views/move_view.jsx
+++ b/frontend/src/views/move_view.jsx
@@ -13,7 +13,6 @@ import SignoutButton from '../components/shared/sign_out_button';
 const Move_view = () => {
   const { id } = useParams();
   const navigate = useNavigate(); 
-  const { data: auth, loading: authloading, error: authError} = useFetchData('auth/admin');
   const { data: device, loading, error } = useFetchData('devices/' + id);
   const [errorMessage, setErrorMessage] = useState(null);
   const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -122,8 +121,8 @@ const Move_view = () => {
         textWrap: 'nowrap',
         gap: 2
     }}>
-          <NavigationBar auth={auth} />
-          {!authloading && auth && !authError && <SignoutButton auth={auth} />}
+          <NavigationBar/>
+          <SignoutButton />
           <Typography sx={{
             fontSize: 'clamp(1.5rem, 5vw, 2.4rem)', 
             textAlign: 'center',


### PR DESCRIPTION
### Changed Nav Bar and Signout Button to use localStorage instead of doing API calls for authentication.

* Ticket had only Nav Bar but since Signout was done with the same logic fix was applied to that as well.
* Changed unit tests to accommodate
* Removed unnecessary auth checks from views where possible.

Closes #246 